### PR TITLE
Add OpenAI API key authentication provider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,12 +14,17 @@ repositories {
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
     annotationProcessor("io.micronaut.serde:micronaut-serde-processor")
+    annotationProcessor("io.micronaut.security:micronaut-security-annotations")
 
     implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-sdk")
     implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-oke-workload-identity")
     implementation("io.micronaut.oraclecloud:micronaut-oraclecloud-httpclient-netty")
 
     implementation("io.micronaut.serde:micronaut-serde-jackson")
+    implementation("io.micronaut.security:micronaut-security")
+    implementation("io.micronaut.security:micronaut-security-jwt")
+    implementation("io.micronaut.validation:micronaut-validation")
+    implementation("io.projectreactor:reactor-core")
     compileOnly("io.micronaut:micronaut-http-client")
     runtimeOnly("ch.qos.logback:logback-classic")
     testImplementation("io.micronaut:micronaut-http-client")

--- a/src/main/java/io/martinstyk/security/OpenAiApiKeyAuthenticationProvider.java
+++ b/src/main/java/io/martinstyk/security/OpenAiApiKeyAuthenticationProvider.java
@@ -1,0 +1,92 @@
+package io.martinstyk.security;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.security.authentication.AuthenticationRequest;
+import io.micronaut.security.authentication.AuthenticationResponse;
+import io.micronaut.security.authentication.provider.AuthenticationProvider;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Singleton
+public class OpenAiApiKeyAuthenticationProvider implements AuthenticationProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(OpenAiApiKeyAuthenticationProvider.class);
+    
+    private static final Pattern API_KEY_PATTERN = Pattern.compile("^sk-[a-zA-Z0-9]{48}$");
+
+    public OpenAiApiKeyAuthenticationProvider() {
+    }
+
+    public AuthenticationResponse authenticate(HttpRequest<?> httpRequest, 
+                                               AuthenticationRequest<?, ?> authenticationRequest) {
+        String apiKey = extractApiKey(httpRequest);
+
+        if (!isValidApiKeyFormat(apiKey)) {
+            return AuthenticationResponse.failure("Invalid API key format");
+        }
+
+        String organization = extractOrganization(httpRequest);
+        String project = extractProject(httpRequest);
+        
+        Map<String, Object> attributes = Map.of(
+            "apiKey", apiKey,
+            "organization", organization,
+            "project", project,
+            "authType", "api-key"
+        );
+        
+        return AuthenticationResponse.success("api-user", attributes);
+    }
+
+    private String extractApiKey(HttpRequest<?> httpRequest) {
+        String authHeader = httpRequest.getHeaders().get("Authorization");
+        
+        if (authHeader == null || authHeader.isEmpty()) {
+            return null;
+        }
+        
+        if (!authHeader.startsWith("Bearer ")) {
+            return null;
+        }
+        
+        return authHeader.substring(7).trim();
+    }
+
+    private String extractOrganization(HttpRequest<?> httpRequest) {
+        String orgHeader = httpRequest.getHeaders().get("OpenAI-Organization");
+        return orgHeader != null ? orgHeader : "org-default";
+    }
+
+    private String extractProject(HttpRequest<?> httpRequest) {
+        String projHeader = httpRequest.getHeaders().get("OpenAI-Project");
+        return projHeader != null ? projHeader : "proj-default";
+    }
+
+    private boolean isValidApiKeyFormat(String apiKey) {
+        if (apiKey == null || apiKey.isEmpty()) {
+            return false;
+        }
+        
+        if (!apiKey.startsWith("sk-")) {
+            return false;
+        }
+        
+        if (apiKey.length() != 51) {
+            return false;
+        }
+        
+        return API_KEY_PATTERN.matcher(apiKey).matches();
+    }
+
+    @Override
+    public AuthenticationResponse authenticate(Object httpRequest, AuthenticationRequest authenticationRequest) {
+        if (httpRequest instanceof HttpRequest<?>) {
+            return authenticate((HttpRequest<?>) httpRequest, authenticationRequest);
+        }
+        return AuthenticationResponse.failure("Invalid request type");
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 micronaut.application.name=openai-oci-gateway
+micronaut.security.enabled=true

--- a/src/test/java/io/martinstyk/security/OpenAiApiKeyAuthenticationProviderTest.java
+++ b/src/test/java/io/martinstyk/security/OpenAiApiKeyAuthenticationProviderTest.java
@@ -1,0 +1,218 @@
+package io.martinstyk.security;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.security.authentication.AuthenticationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpenAiApiKeyAuthenticationProviderTest {
+
+    private OpenAiApiKeyAuthenticationProvider authProvider;
+
+    @BeforeEach
+    void setUp() {
+        authProvider = new OpenAiApiKeyAuthenticationProvider();
+    }
+
+    @Test
+    void testValidApiKeyAuthentication() {
+        String validApiKey = "sk-123456789012345678901234567890123456789012345678";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer " + validApiKey)
+                .header("OpenAI-Organization", "org-test")
+                .header("OpenAI-Project", "proj-test");
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertTrue(result.isAuthenticated());
+        assertTrue(result.getAuthentication().isPresent());
+        assertEquals("api-user", result.getAuthentication().get().getName());
+    }
+
+    @Test
+    void testInvalidApiKeyFormat() {
+        String invalidApiKey = "invalid-key";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer " + invalidApiKey);
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    @Test
+    void testMissingAuthorizationHeader() {
+        HttpRequest<?> request = HttpRequest.GET("/test");
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    @Test
+    void testInvalidBearerFormat() {
+        String validApiKey = "sk-123456789012345678901234567890123456789012345678";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", validApiKey);
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    @Test
+    void testApiKeyFormatValidation() {
+        assertTrue(isValidApiKeyFormat("sk-123456789012345678901234567890123456789012345678"));
+        
+        assertFalse(isValidApiKeyFormat("sk-123"));
+        assertFalse(isValidApiKeyFormat("sk-1234567890123456789012345678901234567890123456789"));
+        assertFalse(isValidApiKeyFormat("pk-123456789012345678901234567890123456789012345678"));
+        assertFalse(isValidApiKeyFormat("sk-12345678901234567890123456789012345678901234567!"));
+    }
+
+    @Test
+    void testOrganizationAndProjectExtraction() {
+        String validApiKey = "sk-123456789012345678901234567890123456789012345678";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer " + validApiKey)
+                .header("OpenAI-Organization", "org-custom")
+                .header("OpenAI-Project", "proj-custom");
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertTrue(result.isAuthenticated());
+        assertTrue(result.getAuthentication().isPresent());
+        
+        Map<String, Object> attributes = result.getAuthentication().get().getAttributes();
+        assertEquals("org-custom", attributes.get("organization"));
+        assertEquals("proj-custom", attributes.get("project"));
+    }
+
+    @Test
+    void testDefaultOrganizationAndProject() {
+        String validApiKey = "sk-123456789012345678901234567890123456789012345678";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer " + validApiKey);
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertTrue(result.isAuthenticated());
+        assertTrue(result.getAuthentication().isPresent());
+        
+        Map<String, Object> attributes = result.getAuthentication().get().getAttributes();
+        assertEquals("org-default", attributes.get("organization"));
+        assertEquals("proj-default", attributes.get("project"));
+    }
+
+    @Test
+    void testAuthenticationAttributes() {
+        String validApiKey = "sk-123456789012345678901234567890123456789012345678";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer " + validApiKey)
+                .header("OpenAI-Organization", "test-org")
+                .header("OpenAI-Project", "test-proj");
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertTrue(result.isAuthenticated());
+        assertTrue(result.getAuthentication().isPresent());
+        
+        Map<String, Object> attributes = result.getAuthentication().get().getAttributes();
+        assertEquals(validApiKey, attributes.get("apiKey"));
+        assertEquals("test-org", attributes.get("organization"));
+        assertEquals("test-proj", attributes.get("project"));
+        assertEquals("api-key", attributes.get("authType"));
+    }
+
+    @Test
+    void testEmptyBearerToken() {
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer ");
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    @Test
+    void testApiKeyTooShort() {
+        String tooShortApiKey = "sk-12345678901234567890123456789012345678901234567";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer " + tooShortApiKey);
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    @Test
+    void testApiKeyTooLong() {
+        String tooLongApiKey = "sk-1234567890123456789012345678901234567890123456789";
+        
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer " + tooLongApiKey);
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    @Test
+    void testWhitespaceOnlyBearerToken() {
+        HttpRequest<?> request = HttpRequest.GET("/test")
+                .header("Authorization", "Bearer   ");
+
+        AuthenticationResponse result = authProvider.authenticate((Object) request, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    @Test
+    void testInvalidRequestType() {
+        String invalidRequest = "not-an-http-request";
+        
+        AuthenticationResponse result = authProvider.authenticate(invalidRequest, null);
+        
+        assertNotNull(result);
+        assertFalse(result.isAuthenticated());
+    }
+
+    private boolean isValidApiKeyFormat(String apiKey) {
+        if (apiKey == null || apiKey.isEmpty()) {
+            return false;
+        }
+        
+        if (!apiKey.startsWith("sk-")) {
+            return false;
+        }
+        
+        if (apiKey.length() != 51) {
+            return false;
+        }
+        
+        String keyPart = apiKey.substring(3);
+        return keyPart.matches("[a-zA-Z0-9]+");
+    }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds Bearer token API key authentication for incoming requests.
  - Supports optional organization and project headers with sensible defaults.
- Security
  - Enables application-wide security.
  - Enforces strict API key validation (prefix, length, and character rules).
- Tests
  - Introduces comprehensive tests covering successful and failed authentication scenarios, header handling, and edge cases.
- Chores
  - Adds security, validation, and reactive dependencies.
  - Configures security enablement in application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->