### PR TITLE
Simplify model resolver to use naive OpenAI prefix approach

### DIFF
--- a/src/main/java/io/martinstyk/config/GenAiProperties.java
+++ b/src/main/java/io/martinstyk/config/GenAiProperties.java
@@ -1,11 +1,8 @@
 package io.martinstyk.config;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.validation.Validated;
 import jakarta.validation.constraints.NotBlank;
-import java.util.HashMap;
-import java.util.Map;
 
 @ConfigurationProperties("genai")
 @Validated
@@ -14,21 +11,11 @@ public class GenAiProperties {
     @NotBlank(message = "Compartment ID cannot be blank")
     private String compartmentId;
 
-    private Map<String, String> modelMapping = new HashMap<>();
-
     public String getCompartmentId() {
         return compartmentId;
     }
 
     public void setCompartmentId(String compartmentId) {
         this.compartmentId = compartmentId;
-    }
-
-    public Map<String, String> getModelMapping() {
-        return modelMapping;
-    }
-
-    public void setModelMapping(@NonNull Map<String, String> modelMapping) {
-        this.modelMapping = modelMapping;
     }
 }

--- a/src/main/java/io/martinstyk/service/ModelResolverService.java
+++ b/src/main/java/io/martinstyk/service/ModelResolverService.java
@@ -1,28 +1,40 @@
 package io.martinstyk.service;
 
-import io.martinstyk.config.GenAiProperties;
 import jakarta.inject.Singleton;
-import java.util.Map;
 
 @Singleton
 public class ModelResolverService {
-    private final GenAiProperties properties;
-
-    public ModelResolverService(GenAiProperties properties) {
-        this.properties = properties;
-    }
+    public static final String MODEL_PREFIX = "openai.";
 
     public String resolveModel(String inputModelName) {
-        Map<String, String> mapping = properties.getModelMapping();
-
-        if (mapping.containsKey(inputModelName)) {
-            return mapping.get(inputModelName);
+        if (inputModelName == null || inputModelName.trim().isEmpty()) {
+            throw new UnrecognizedModelException("Model name cannot be null or empty");
         }
 
-        if (mapping.containsValue(inputModelName)) {
+        if (inputModelName.startsWith(MODEL_PREFIX)) {
             return inputModelName;
         }
 
-        throw new UnrecognizedModelException("Unrecognized model name: " + inputModelName);
+        return MODEL_PREFIX + inputModelName;
+    }
+
+    public String resolveToOpenAiModel(String genaiModelName) {
+        if (genaiModelName == null || genaiModelName.trim().isEmpty()) {
+            throw new UnrecognizedModelException("Model name cannot be null or empty");
+        }
+
+        if (!genaiModelName.startsWith(MODEL_PREFIX)) {
+            throw new UnrecognizedModelException(
+                    "GenAI model name must start with '"
+                            + MODEL_PREFIX
+                            + "' prefix: "
+                            + genaiModelName);
+        }
+
+        String openAiModelName = genaiModelName.substring(MODEL_PREFIX.length()).trim();
+        if (openAiModelName.isEmpty()) {
+            throw new UnrecognizedModelException("Model name cannot be null or empty");
+        }
+        return openAiModelName;
     }
 }

--- a/src/test/java/io/martinstyk/service/ModelResolverServiceTest.java
+++ b/src/test/java/io/martinstyk/service/ModelResolverServiceTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.martinstyk.config.GenAiProperties;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,52 +12,46 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ModelResolverServiceTest {
-
-    private GenAiProperties genAiProperties;
     private ModelResolverService modelResolverService;
 
     @BeforeEach
     void setUp() {
-        genAiProperties = new GenAiProperties();
-        modelResolverService = new ModelResolverService(genAiProperties);
+        modelResolverService = new ModelResolverService();
     }
 
     @Test
-    void testResolveMappedModel() {
-        Map<String, String> mapping = new HashMap<>();
-        mapping.put("gpt-4", "cohere.command-r-plus");
-        mapping.put("gpt-3.5-turbo", "cohere.command-r");
-        mapping.put("claude-3", "meta.llama-3.1-70b-instruct");
-        genAiProperties.setModelMapping(mapping);
-
+    void testResolveOpenAiModelWithPrefix() {
         String result = modelResolverService.resolveModel("gpt-4");
-
-        assertEquals("cohere.command-r-plus", result);
+        assertEquals(ModelResolverService.MODEL_PREFIX + "gpt-4", result);
     }
 
     @Test
-    void testResolveDirectTargetModel() {
-        Map<String, String> mapping = new HashMap<>();
-        mapping.put("gpt-4", "cohere.command-r-plus");
-        mapping.put("gpt-3.5-turbo", "cohere.command-r");
-        mapping.put("claude-3", "meta.llama-3.1-70b-instruct");
-        genAiProperties.setModelMapping(mapping);
+    void testResolveModelAlreadyWithPrefix() {
+        String result =
+                modelResolverService.resolveModel(ModelResolverService.MODEL_PREFIX + "gpt-4");
+        assertEquals(ModelResolverService.MODEL_PREFIX + "gpt-4", result);
+    }
 
-        String result = modelResolverService.resolveModel("cohere.command-r-plus");
-        assertEquals("cohere.command-r-plus", result);
+    @Test
+    void testResolveVariousModelNames() {
+        assertEquals(
+                ModelResolverService.MODEL_PREFIX + "gpt-3.5-turbo",
+                modelResolverService.resolveModel("gpt-3.5-turbo"));
+        assertEquals(
+                ModelResolverService.MODEL_PREFIX + "gpt-4-turbo",
+                modelResolverService.resolveModel("gpt-4-turbo"));
+        assertEquals(
+                ModelResolverService.MODEL_PREFIX + "text-davinci-003",
+                modelResolverService.resolveModel("text-davinci-003"));
+        assertEquals(
+                ModelResolverService.MODEL_PREFIX + "model-with-dashes_and.underscores",
+                modelResolverService.resolveModel("model-with-dashes_and.underscores"));
     }
 
     @ParameterizedTest
     @MethodSource("provideExceptionTestCases")
-    void testUnrecognizedModelExceptions(
+    void testInvalidModelNames(
             String inputModel, String expectedMessageContent, String testDescription) {
-        Map<String, String> mapping = new HashMap<>();
-        mapping.put("gpt-4", "cohere.command-r-plus");
-        mapping.put("gpt-4-turbo", "cohere.command-r-plus");
-        mapping.put("claude-3-opus", "meta.llama-3.1-70b-instruct");
-        mapping.put("special-chars", "model-with-dashes_and.underscores");
-        genAiProperties.setModelMapping(mapping);
-
         UnrecognizedModelException thrown =
                 assertThrows(
                         UnrecognizedModelException.class,
@@ -72,35 +63,122 @@ class ModelResolverServiceTest {
 
     private static Stream<Arguments> provideExceptionTestCases() {
         return Stream.of(
-                Arguments.of("unknown-model", "unknown-model", "unrecognized model"),
-                Arguments.of(null, "null", "null input"),
-                Arguments.of("", "", "empty string input"),
-                Arguments.of("   ", "   ", "whitespace-only input"),
-                Arguments.of("GPT-4", "GPT-4", "case-sensitive mapping with different case"));
-    }
-
-    @Test
-    void testMultipleMappingsToSameTarget() {
-        Map<String, String> mapping = new HashMap<>();
-        mapping.put("gpt-4", "cohere.command-r-plus");
-        mapping.put("gpt-4-turbo", "cohere.command-r-plus");
-        mapping.put("claude-3-opus", "meta.llama-3.1-70b-instruct");
-        mapping.put("special-chars", "model-with-dashes_and.underscores");
-        genAiProperties.setModelMapping(mapping);
-
-        assertEquals("cohere.command-r-plus", modelResolverService.resolveModel("gpt-4"));
-        assertEquals("cohere.command-r-plus", modelResolverService.resolveModel("gpt-4-turbo"));
+                Arguments.of(null, "Model name cannot be null or empty", "null input"),
+                Arguments.of("", "Model name cannot be null or empty", "empty string input"),
+                Arguments.of("   ", "Model name cannot be null or empty", "whitespace-only input"));
     }
 
     @Test
     void testVeryLongModelNames() {
         String longModelName =
                 "very-long-model-name-with-many-characters-that-should-still-work-properly";
-        Map<String, String> mapping = new HashMap<>();
-        mapping.put(longModelName, "target-model");
-        genAiProperties.setModelMapping(mapping);
-
         String result = modelResolverService.resolveModel(longModelName);
-        assertEquals("target-model", result);
+        assertEquals(ModelResolverService.MODEL_PREFIX + longModelName, result);
+    }
+
+    @Test
+    void testCaseSensitiveModelNames() {
+        assertEquals(
+                ModelResolverService.MODEL_PREFIX + "GPT-4",
+                modelResolverService.resolveModel("GPT-4"));
+        assertEquals(
+                ModelResolverService.MODEL_PREFIX + "gpt-4",
+                modelResolverService.resolveModel("gpt-4"));
+        assertEquals(
+                ModelResolverService.MODEL_PREFIX + "OpenAI-GPT",
+                modelResolverService.resolveModel("OpenAI-GPT"));
+    }
+
+    @Test
+    void testResolveToOpenAiModel() {
+        assertEquals(
+                "gpt-4",
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + "gpt-4"));
+        assertEquals(
+                "gpt-3.5-turbo",
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + "gpt-3.5-turbo"));
+        assertEquals(
+                "text-davinci-003",
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + "text-davinci-003"));
+    }
+
+    @Test
+    void testResolveToOpenAiModelWithSpecialCharacters() {
+        assertEquals(
+                "model-with-dashes_and.underscores",
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + "model-with-dashes_and.underscores"));
+    }
+
+    @Test
+    void testResolveToOpenAiModelCaseSensitive() {
+        assertEquals(
+                "GPT-4",
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + "GPT-4"));
+        assertEquals(
+                "gpt-4",
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + "gpt-4"));
+        assertEquals(
+                "OpenAI-GPT",
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + "OpenAI-GPT"));
+    }
+
+    @Test
+    void testResolveToOpenAiModelVeryLongNames() {
+        String longModelName =
+                "very-long-model-name-with-many-characters-that-should-still-work-properly";
+        assertEquals(
+                longModelName,
+                modelResolverService.resolveToOpenAiModel(
+                        ModelResolverService.MODEL_PREFIX + longModelName));
+    }
+
+    @Test
+    void testResolveToOpenAiModelEmptyModel() {
+        String emptyModelName = "";
+        UnrecognizedModelException thrown =
+                assertThrows(
+                        UnrecognizedModelException.class,
+                        () -> modelResolverService.resolveToOpenAiModel(emptyModelName),
+                        "Expected resolveToOpenAiModel() to throw for " + emptyModelName);
+        assertTrue(thrown.getMessage().contains("Model name cannot be null or empty"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideReverseExceptionTestCases")
+    void testResolveToOpenAiModelExceptions(
+            String inputModel, String expectedMessageContent, String testDescription) {
+        UnrecognizedModelException thrown =
+                assertThrows(
+                        UnrecognizedModelException.class,
+                        () -> modelResolverService.resolveToOpenAiModel(inputModel),
+                        "Expected resolveToOpenAiModel() to throw for " + testDescription);
+
+        assertTrue(thrown.getMessage().contains(expectedMessageContent));
+    }
+
+    private static Stream<Arguments> provideReverseExceptionTestCases() {
+        return Stream.of(
+                Arguments.of(null, "Model name cannot be null or empty", "null input"),
+                Arguments.of("", "Model name cannot be null or empty", "empty string input"),
+                Arguments.of("   ", "Model name cannot be null or empty", "whitespace-only input"),
+                Arguments.of(
+                        "gpt-4",
+                        "GenAI model name must start with '"
+                                + ModelResolverService.MODEL_PREFIX
+                                + "' prefix",
+                        "missing prefix"),
+                Arguments.of(
+                        "cohere.command-r-plus",
+                        "GenAI model name must start with '"
+                                + ModelResolverService.MODEL_PREFIX
+                                + "' prefix",
+                        "wrong prefix"));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Standardized model name handling using a common prefix; plain names are auto-prefixed, already prefixed names pass through.
  - Removed custom mapping configuration from settings; use the standard prefix format instead.
  - Stricter input validation with clearer error messages for null/empty and incorrect prefixes.
  - Added support to convert prefixed names back to base names when needed.

- Tests
  - Expanded coverage for diverse name formats, prefix behavior, round-trip conversions, and error handling; simplified test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->